### PR TITLE
Monitoring and bugfix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,10 @@ dependencies {
 
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "io.grpc:grpc-netty:latest.release"
+    compile "io.prometheus:simpleclient_common:latest.release"
+    compile "io.prometheus:simpleclient:latest.release"
+    compile "io.prometheus:simpleclient_hotspot:latest.release"
+    compile "io.prometheus:simpleclient_httpserver:latest.release"
     compile "com.xenomachina:kotlin-argparser:latest.release"
     compile 'com.google.cloud:google-cloud-storage:latest.release'
     compile 'com.google.cloud:google-cloud-datastore:latest.release'
@@ -68,6 +72,7 @@ sourceSets {
         proto {
         }
         java {
+            srcDirs "$projectDir/src/generated/main/java", "$projectDir/src/generated/main/grpc"
         }
     }
     libproto {

--- a/src/main/kotlin/com/bardsoftware/papeeria/backend/cosmas/CosmasGoogleCloudService.kt
+++ b/src/main/kotlin/com/bardsoftware/papeeria/backend/cosmas/CosmasGoogleCloudService.kt
@@ -78,7 +78,7 @@ class CosmasGoogleCloudService(
                     .build()
             )
         }.build().service,
-    private val ticker: Ticker = Ticker.systemTicker(),
+    private val ticker: Ticker = WALL_TIME_TICKER,
     private val windowMaxSize: Int = 10,
     private val cacheBuilderSpec: String = "expireAfterAccess=5m") : CosmasGrpc.CosmasImplBase() {
 
@@ -766,4 +766,10 @@ class CosmasGoogleCloudService(
     }
 
     private fun currentTimeMillis(): Long = ticker.read() / 1000000 // Ticker returns time in nanoseconds
+}
+
+private object WALL_TIME_TICKER: Ticker() {
+    override fun read(): Long {
+        return System.currentTimeMillis() * 1000000L // 1m nanos in 1ms
+    }
 }

--- a/src/main/kotlin/com/bardsoftware/papeeria/backend/cosmas/CosmasServer.kt
+++ b/src/main/kotlin/com/bardsoftware/papeeria/backend/cosmas/CosmasServer.kt
@@ -27,6 +27,8 @@ import java.io.File
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 
+
+
 private val LOG = LoggerFactory.getLogger("CosmasServer")
 
 /**
@@ -104,8 +106,10 @@ fun main(args: Array<String>) = mainBody {
                         CosmasGoogleCloudService(bucket))
             }
 
-    LOG.info("Listening on port ${arg.port}")
     server.start()
+    exportMetricz(arg.metriczPort)
+    LOG.info("Listening on port ${arg.port}. Exposing metricz on port ${arg.metriczPort}")
+
     server.blockUntilShutDown()
 }
 
@@ -118,4 +122,6 @@ class CosmasServerArgs(parser: ArgParser) {
             help = "path to SSL key").default { null }
     val bucket: String? by parser.storing("--bucket",
             help = "GCS bucket where version history will be stored").default { null }
+    val metriczPort: Int by parser.storing("--metricz-port",
+        help = "HTTP port for exposing metricz (default 9700)") { toInt() }.default { 9700 }
 }

--- a/src/main/kotlin/com/bardsoftware/papeeria/backend/cosmas/Monitoring.kt
+++ b/src/main/kotlin/com/bardsoftware/papeeria/backend/cosmas/Monitoring.kt
@@ -1,0 +1,25 @@
+/**
+Copyright 2019 BarD Software s.r.o
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package com.bardsoftware.papeeria.backend.cosmas
+
+import io.prometheus.client.exporter.HTTPServer
+import io.prometheus.client.hotspot.DefaultExports
+
+private lateinit var ourMetriczServer: HTTPServer
+
+fun exportMetricz(port: Int) {
+  DefaultExports.initialize()
+  ourMetriczServer = HTTPServer(port)
+}


### PR DESCRIPTION
* Metricz will be published on port 9700 by default
* Ticker bugfix (it would mark all versions circa 1970 otherwise)